### PR TITLE
Update dvui, use system SDL2 on macOS

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,8 +3,8 @@
     .version = "0.0.1",
     .dependencies = .{
         .dvui = .{
-            .url = "https://github.com/david-vanderson/dvui/archive/c822c2354d7a70cb0af7244390d88027c5485705.tar.gz",
-            .hash = "1220963768e9294855838ff79c97e2ec874520ab62adffabfa77d176036937edc87f",
+            .url = "https://github.com/david-vanderson/dvui/archive/789c43319c66c42e1b534197c27cbd40070f6a61.tar.gz",
+            .hash = "1220eb8ed4b22e8897a8e82a4ed812b7065e1b55906bdb396f9345bce73cabd8c086",
         },
     },
 }


### PR DESCRIPTION
This PR updates DVUI and makes the build system link to the system installation of SDL2 instead of trying to build it from scratch using the bindings (which does not work, it throws a cross-compile error even when compiling for the native target).